### PR TITLE
fix: cross-env needs to prefix all individual commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start-prod-set": "set NODE_ENV=production&& webpack --config webpack.production.config.js && node server.js",
     "start-dev-cross": "cross-env NODE_ENV=dev node server.js",
     "start-prod-cross": "cross-env NODE_ENV=production node server.js",
-    "start-dev-cross-webpack": "cross-env NODE_ENV=dev webpack --config webpack.config.js && node server.js",
-    "start-dev-cross-webpack": "cross-env NODE_ENV=production webpack --config webpack.production.config.js && node server.js"
+    "start-dev-cross-webpack": "cross-env NODE_ENV=dev webpack --config webpack.config.js && cross-env NODE_ENV=dev node server.js",
+    "start-prod-cross-webpack": "cross-env NODE_ENV=production webpack --config webpack.production.config.js && cross-env NODE_ENV=production node server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The problem is that each command separated by `&&` is actually totally isolated from one another, so `cross-env` can't do anything about other isolated commands. So you need to prefix each one.

This is noted in [the docs](https://github.com/kentcdodds/cross-env#known-limitations).

I'm sorry it took so long to get back to you.
